### PR TITLE
Target explicit Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For the frontend repository, which contains the web interface for configuration 
 
 ## Usage
 
-You'll want a recent [Node](https://nodejs.org/en/download/), [Yarn 1.x](https://classic.yarnpkg.com/en/docs/install), and a [MongoDB](https://www.mongodb.com/) 3.6+ instance (self-hosted or on [Atlas](https://www.mongodb.com/cloud/atlas)). Make sure your Discord bot has the server members intent - it's required for now ([#76](https://github.com/r-anime/misato/issues/76)).
+You'll want [Node](https://nodejs.org/en/download/) 12+, [Yarn 1.x](https://classic.yarnpkg.com/en/docs/install), and a [MongoDB](https://www.mongodb.com/) 3.6+ instance (self-hosted or on [Atlas](https://www.mongodb.com/cloud/atlas)). Make sure your Discord bot has the server members intent - it's required for now ([#76](https://github.com/r-anime/misato/issues/76)).
 
 ```bash
 # Install dependencies

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,12 @@
 		"allowJs": true,
 		"outDir": "build",
 		"skipLibCheck": true,
-		"esModuleInterop": true
+		"esModuleInterop": true,
+		// Minimum target is Node 12
+		// See https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
+		"target": "ES2019",
+		"lib": ["ES2019"],
+		"module": "commonjs"
 	},
 	"include": [
 		"src"


### PR DESCRIPTION
Ties the project to Node 12+. Fixes strange issues with roles not being returned from the API because of strange behavior with `--allowJs` but not `--checkJs` - see https://github.com/microsoft/TypeScript/issues/45251 for more detail.