### PR TITLE
Allow cross-origin requests outside production

### DIFF
--- a/src/web/middleware/accessControl.js
+++ b/src/web/middleware/accessControl.js
@@ -1,0 +1,11 @@
+// A middleware that adds the header `Access-Control-Allow-Origin: *` to all
+// outgoing requests.
+export default (request, response, next) => {
+	if (request.headers.origin) {
+		response.setHeader('access-control-allow-origin', request.headers.origin);
+	} else {
+		response.setHeader('access-control-allow-origin', '*');
+	}
+	response.setHeader('access-control-allow-credentials', 'true');
+	next();
+};


### PR DESCRIPTION
Enables testing the frontend and the API on different origins in development. This will be necessary for a local test of the frontend and API together, since both their dev modes live on different ports and therefore different origins.