### PR TITLE
Remove hardcode from generic auth check

### DIFF
--- a/src/web/routes/channelAutomation.js
+++ b/src/web/routes/channelAutomation.js
@@ -81,11 +81,7 @@ export default (db, client) => polka()
 		const {guildID} = request.params;
 
 		// TODO: hardcoded
-		if (guildID !== config.TEMP_guildID) {
-			return;
-		}
-
-		if (!await util.thisUserManagesGuild(request, client, db, guildID)) {
+		if (guildID !== config.TEMP_guildID || !await util.thisUserManagesGuild(request, client, db, guildID)) {
 			response.writeHead(401);
 			response.end();
 			return;
@@ -107,11 +103,7 @@ export default (db, client) => polka()
 		const {guildID} = request.params;
 
 		// TODO: hardcoded
-		if (guildID !== config.TEMP_guildID) {
-			return;
-		}
-
-		if (!await util.thisUserManagesGuild(request, client, db, guildID)) {
+		if (guildID !== config.TEMP_guildID || !await util.thisUserManagesGuild(request, client, db, guildID)) {
 			response.writeHead(401);
 			response.end();
 			return;

--- a/src/web/util.js
+++ b/src/web/util.js
@@ -14,8 +14,6 @@ export const asyncFilter = (arr, predicate) => Promise.all(arr.map(predicate)).t
  */
 export async function thisUserManagesGuild (request, bot, db, guildID) {
 	if (!request.session.discordUserInfo) return false;
-	// TODO: hardcoded
-	if (guildID !== config.TEMP_guildID) return false;
 
 	const guild = bot.guilds.get(guildID);
 	if (!guild) return false;

--- a/src/web/util.js
+++ b/src/web/util.js
@@ -1,5 +1,3 @@
-import config from '../../config';
-
 export const asyncFilter = (arr, predicate) => Promise.all(arr.map(predicate)).then(results => arr.filter((_v, index) => results[index]));
 
 // TODO: make generic. probably need to set up some generic per-guild group


### PR DESCRIPTION
Doesn't totally remove `TEMP_guildID`, but does remove it from routes where it isn't necessary. The production bot is not public at the moment, so it's safe to assume that we're the only guild the bot is in, and therefore it's not necessary to explicitly check this.