### PR TITLE
Specify intents explicitly

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -4,6 +4,7 @@
 import path from 'path';
 
 import {Client} from 'yuuko';
+import {Constants} from 'eris';
 import createLogger from 'another-logger';
 const log = createLogger({label: 'discord'});
 
@@ -14,6 +15,7 @@ export default (mongoClient, db) => {
 	const bot = new Client({
 		token: config.discord.token,
 		prefix: config.discord.prefix,
+		intents: Constants.Intents.all,
 		disableDefaultMessageListener: true,
 		restMode: true,
 		// HACK: required for user lookup by tag, better options available


### PR DESCRIPTION
Makes sure we have access to message content (yuuko still doesn't support application commands) and guild members (since we still use `getAllUsers` for now, #76). In the future we can customize this to exclude intents we don't need, like probably typing events and stuff like that.