### PR TITLE
Revert "Specify intents explicitly"

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -4,7 +4,6 @@
 import path from 'path';
 
 import {Client} from 'yuuko';
-import {Constants} from 'eris';
 import createLogger from 'another-logger';
 const log = createLogger({label: 'discord'});
 
@@ -15,7 +14,6 @@ export default (mongoClient, db) => {
 	const bot = new Client({
 		token: config.discord.token,
 		prefix: config.discord.prefix,
-		intents: Constants.Intents.all,
 		disableDefaultMessageListener: true,
 		restMode: true,
 		// HACK: required for user lookup by tag, better options available


### PR DESCRIPTION
Reverts r-anime/misato#182. Somehow specifying `Constants.Intents.all` doesn't give the `guildMembers` intent, so client construction errors out with `Error: Cannot request all members without guildMembers intent.`

![Server logs screenshot](https://user-images.githubusercontent.com/4165301/167216628-a4c1d219-35f7-4ddf-8fc2-c80bca67a9c1.png)
