### PR TITLE
Minor improvements to text

### DIFF
--- a/src/bot/commands/moderation/ban.js
+++ b/src/bot/commands/moderation/ban.js
@@ -101,6 +101,6 @@ const command = new Command('ban', async (message, args, context) => {
 });
 command.help = {
 	args: '<user> <duration> [message]',
-	desc: 'Ban the indicated user for the indicated duration with the indicated message. If Duration is blank, ban will be perminent.',
+	desc: 'Ban the indicated user for the indicated duration with the indicated message. If Duration is blank, ban will be permanent.',
 };
 export default command;

--- a/src/bot/commands/whois.js
+++ b/src/bot/commands/whois.js
@@ -144,7 +144,7 @@ const command = new Command('whois', async (message, args, context) => {
 		return;
 	}
 	const content = (await Promise.all([
-		`__Website: **<${config.web.host}/guilds/${message.channel.guild.id}/members/${user.id}>**__`,
+		`__Website: \n**<${config.web.host}/guilds/${message.channel.guild.id}/members/${user.id}>**__`,
 		`__User: **<@${user.id}> (${user.username}#${user.discriminator})**__`,
 		`__Account Age: **${formatDate(new Date(user.createdAt))}**__`,
 		isUserStillMember(message.channel.guild, user.id),


### PR DESCRIPTION
The URL shown by `.whois` now appears on the next line. Also fixed a spelling mistake.
It looks like this:
![image](https://user-images.githubusercontent.com/102722190/169662635-019d71f3-71be-46dd-bc71-9dd4e04c104e.png)
