### PR TITLE
Make bot log when a user stops boosting and when they leave

### DIFF
--- a/src/bot/events/trackBoosters.js
+++ b/src/bot/events/trackBoosters.js
@@ -1,0 +1,16 @@
+import {EventListener} from 'yuuko';
+import config from '../../../config';
+
+export default new EventListener('guildMemberUpdate', (guild, member, oldMember, {client}) => {
+	if (member.bot) return;
+	if (guild.id !== config.TEMP_guildID) return;
+
+	if (oldMember.premiumSince !== null && member.premiumSince === null) {
+		client.createMessage(config.TEMP_loggingChannelID, {
+			content: `User **<@${member.id}> (${member.username}#${member.discriminator})** has stopped boosting`,
+			allowedMentions: {
+				users: false,
+			},
+		}).catch(() => {});
+	}
+});

--- a/src/bot/events/trackMembersLeaving.js
+++ b/src/bot/events/trackMembersLeaving.js
@@ -1,0 +1,24 @@
+import {EventListener} from 'yuuko';
+import config from '../../../config';
+
+export default new EventListener('guildMemberRemove', async (guild, member, {client}) => {
+	if (member.bot) return;
+	if (guild.id !== config.TEMP_guildID) return;
+
+	if (member.premiumSince !== null) {
+		await client.createMessage(config.TEMP_loggingChannelID, {
+			content: `User **<@${member.id}> (${member.username}#${member.discriminator})** has stopped boosting`,
+			allowedMentions: {
+				users: false,
+			},
+		}).catch(() => {});
+	}
+
+
+	await client.createMessage(config.TEMP_loggingChannelID, {
+		content: `User **<@${member.id}> (${member.username}#${member.discriminator})** has left the server`,
+		allowedMentions: {
+			users: false,
+		},
+	}).catch(() => {});
+});


### PR DESCRIPTION
The bot will now log when a user stops boosting. If a user leaves while being a booster then it will log that they left and that they stopped boosting since the boost is removed automatically.

The messages will look like this:
![image](https://user-images.githubusercontent.com/102722190/172640676-8edf6b09-9b06-43b3-99da-2464127e91d8.png)
