### PR TITLE
Build Typescript as part of CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 on:
 - push
 - pull_request
@@ -14,5 +14,7 @@ jobs:
         node-version: '12'
     - name: Install Dependencies
       run: npm ci
-    - name: Run lint task
+    - name: Lint
       run: npm run lint
+    - name: Build
+      run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ config.*
 
 # Built frontend bundles
 web/frontend/dist
+
+# Typescript builds
+build

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "src/index.js",
   "scripts": {
+    "build": "tsc",
     "lint": "eslint src --ext js,ts",
     "lint:fix": "eslint src --ext js,ts --fix",
     "start": "ts-node src/index.js",


### PR DESCRIPTION
The build output doesn't actually matter since we use `ts-node` in production, but making sure the project compiles is probably a good idea