### PR TITLE
use <@!id> for join message mentions

### DIFF
--- a/src/bot/events/messageCreate.js
+++ b/src/bot/events/messageCreate.js
@@ -33,7 +33,7 @@ export default new EventListener('messageCreate', async (message, {client, db}) 
 									},
 									{
 										name: 'Author',
-										value: `<@${message.author.id}>\n\`${message.author.id}\``,
+										value: `<@!${message.author.id}>\n\`${message.author.id}\``,
 										inline: true,
 									},
 								],

--- a/src/bot/events/trackMembersLeaving.js
+++ b/src/bot/events/trackMembersLeaving.js
@@ -6,7 +6,7 @@ export default new EventListener('guildMemberRemove', async (guild, member, {cli
 	if (guild.id !== config.TEMP_guildID) return;
 
 	await client.createMessage(config.TEMP_leavingChannelID, {
-		content: `User **<@${member.id}> (${member.username}#${member.discriminator})** has left the server`,
+		content: `User **<@!${member.id}> (${member.username}#${member.discriminator})** has left the server`,
 		allowedMentions: {
 			users: false,
 		},

--- a/src/bot/events/verification.js
+++ b/src/bot/events/verification.js
@@ -11,7 +11,7 @@ export default new EventListener('guildMemberAdd', async (guild, member, {db, cl
 	if (guild.id !== config.TEMP_guildID) return;
 
 	client.createMessage(config.TEMP_joiningChannelID, {
-		content: `User **<@${member.id}> (${member.username}#${member.discriminator})** has joined \nAccount Created:  ${formatDate(new Date(member.createdAt))} (${formatDateRelative(new Date(member.createdAt))})`,
+		content: `User **<@!${member.id}> (${member.username}#${member.discriminator})** has joined \nAccount Created:  ${formatDate(new Date(member.createdAt))} (${formatDateRelative(new Date(member.createdAt))})`,
 		allowedMentions: {
 			users: false,
 		},


### PR DESCRIPTION
`<@id>` mention format doesn't prompt the client to fetch the user's information if it's not already cached. `<@!id>` does, so using it results in the actual name/nickname of the user showing up more of the time.

Discord lists `<@!id>` as "deprecated" and "should be handled like any other user mention" but... that's not what the client does. so that's cool. https://discord.com/developers/docs/reference#message-formatting