### PR TITLE
Always use latest node for CI runs; update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up node
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: '12'
+        node-version-file: '.nvmrc'
     - name: Install Dependencies
       run: npm ci
     - name: Lint


### PR DESCRIPTION
Updates `@actions/checkout` and `@actions/setup-node` to their latest major versions. Also sets up the workflow to read the node version from `.nvmrc` instead of always using 12 (! that version isn't even LTS anymore!)