### PR TITLE
Ping command improvements

### DIFF
--- a/src/bot/commands/ping.js
+++ b/src/bot/commands/ping.js
@@ -35,7 +35,7 @@ const command = new Command('ping', async msg => {
 
 	const then = Date.now();
 	const newMsg = await msg.channel.createMessage(messageContent);
-	newMsg.edit(newMsg.content.replace('Pong!', `Pong! (${Date.now() - then}ms)`));
+	newMsg.edit(newMsg.content.replace('Pong!', `Pong! (${Date.now() - then}ms REST round-trip)`));
 });
 command.help = {
 	desc: 'Pings the bot and shows how long it takes to send a response. This will also display the current commit hash as well as the repo URL',

--- a/src/bot/commands/ping.js
+++ b/src/bot/commands/ping.js
@@ -1,21 +1,40 @@
 // Tests the bot's response time.
 // Shows the current commit hash and repo URL
 
+import createLogger from 'another-logger';
 import {Command} from 'yuuko';
 import childProcess from 'child_process';
 
-let commitHash;
+const log = createLogger({label: 'cmd:ping'});
+
+let commitHash = null;
 childProcess.exec('git rev-parse --short HEAD', (err, stdout) => {
 	if (err) {
-		commitHash = 'Unknown';
 		return;
 	}
 	commitHash = stdout.trim();
 });
 
+let gitRepoURI = null;
+childProcess.exec('git remote get-url origin', (err, stdout) => {
+	if (err) {
+		log.warn('Failed to fetch git remote URI:', err);
+		return;
+	}
+	gitRepoURI = stdout.trim().replace(/\.git$/, '');
+});
+
 const command = new Command('ping', async msg => {
+	let messageContent = 'Pong!';
+	if (commitHash != null) {
+		messageContent += `\nCommit: ${commitHash}`;
+	}
+	if (gitRepoURI != null) {
+		messageContent += `\nRepo: <${gitRepoURI}>`;
+	}
+
 	const then = Date.now();
-	const newMsg = await msg.channel.createMessage(`Pong!\nCommit: ${commitHash}\nRepo: <https://github.com/r-anime/discord-mod-bot>`);
+	const newMsg = await msg.channel.createMessage(messageContent);
 	newMsg.edit(newMsg.content.replace('Pong!', `Pong! (${Date.now() - then}ms)`));
 });
 command.help = {

--- a/src/bot/commands/ping.js
+++ b/src/bot/commands/ping.js
@@ -24,7 +24,7 @@ childProcess.exec('git remote get-url origin', (err, stdout) => {
 	gitRepoURI = stdout.trim().replace(/\.git$/, '');
 });
 
-const command = new Command('ping', async msg => {
+const command = new Command('ping', async (msg, args, {prefix, client}) => {
 	let messageContent = 'Pong!';
 	if (commitHash != null) {
 		messageContent += `\nCommit: ${commitHash}`;
@@ -32,6 +32,9 @@ const command = new Command('ping', async msg => {
 	if (gitRepoURI != null) {
 		messageContent += `\nRepo: <${gitRepoURI}>`;
 	}
+	// prefix is shown for clarity, but not if a mention was used as the prefix,
+	// because that doesn't show up nicely (logic stolen from yuuko's `help`)
+	messageContent += `\nUse \`${prefix.match(client.mentionPrefixRegExp) ? '' : prefix}help\` for a list of commands.`;
 
 	const then = Date.now();
 	const newMsg = await msg.channel.createMessage(messageContent);


### PR DESCRIPTION
Repo URL is now fetched dynamically from the current environment's `origin` git remote, rather than being hardcoded into the command. Warnings are added for if the current commit or git remote can't be found. Output now includes a nudge towards the help command. The actual meaning of the time displayed is shown. Message formatting code has been restructured to be reasonable.

![image](https://user-images.githubusercontent.com/4165301/174687032-72b9b83f-73b6-4bec-8470-4b45c8aea637.png)
