### PR TITLE
eris@0.17.0, yuuko@2.3.2, use all intents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
         "another-logger": "^2.0.1",
         "connect-mongo": "^3.2.0",
         "convert-units": "^2.3.4",
-        "eris": "^0.15.0",
+        "eris": "^0.17.0",
         "express-session": "^1.17.0",
         "mongodb": "^3.5.5",
         "node-fetch": "^2.6.7",
         "polka": "^1.0.0-next.11",
         "rss-parser": "^3.12.0",
-        "yuuko": "^2.2.1"
+        "yuuko": "^2.3.2"
       },
       "devDependencies": {
         "@types/express-session": "^1.17.4",
@@ -1401,18 +1401,18 @@
       }
     },
     "node_modules/eris": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/eris/-/eris-0.15.1.tgz",
-      "integrity": "sha512-IQ3BPW6OjgFoqjdh+irPOa1jFlkotk+WNu2GQQ7QAQfbzQEPZgn+F+hpOxfMUXPHOZMX4sPKLkVDkMHAssBYhw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/eris/-/eris-0.17.0.tgz",
+      "integrity": "sha512-ba7fpe104uw86z8fbX7V1ORMblB7jMJoDsRpiy8BKDQo+kNCRuUXB5xfg/VKGtZ944QroBTEZDuyXCBhKOBplQ==",
       "dependencies": {
-        "ws": "^7.2.1"
+        "ws": "^8.2.3"
       },
       "engines": {
         "node": ">=10.4.0"
       },
       "optionalDependencies": {
         "opusscript": "^0.0.8",
-        "tweetnacl": "^1.0.1"
+        "tweetnacl": "^1.0.3"
       }
     },
     "node_modules/error-ex": {
@@ -4211,11 +4211,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -4265,11 +4265,11 @@
       }
     },
     "node_modules/yuuko": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yuuko/-/yuuko-2.2.1.tgz",
-      "integrity": "sha512-iPfv7Ftkg6U2uh3HsUoBhznTxVbb/PiXGxxQp6GIuVxtUfC/oy1FiGhCZFJshnK7SgRGnER3SSxuvgsJR//k0A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yuuko/-/yuuko-2.3.2.tgz",
+      "integrity": "sha512-+EoC/tU70FafRhTTxxhPPJoU5odkV7n6EEd/yOvBH1BCignno9REneCGdlA1DMbS5lxoh3vEy1mO5rnRqQWNIA==",
       "peerDependencies": {
-        "eris": "^0.15.0"
+        "eris": "*"
       }
     }
   },
@@ -5287,13 +5287,13 @@
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "eris": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/eris/-/eris-0.15.1.tgz",
-      "integrity": "sha512-IQ3BPW6OjgFoqjdh+irPOa1jFlkotk+WNu2GQQ7QAQfbzQEPZgn+F+hpOxfMUXPHOZMX4sPKLkVDkMHAssBYhw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/eris/-/eris-0.17.0.tgz",
+      "integrity": "sha512-ba7fpe104uw86z8fbX7V1ORMblB7jMJoDsRpiy8BKDQo+kNCRuUXB5xfg/VKGtZ944QroBTEZDuyXCBhKOBplQ==",
       "requires": {
         "opusscript": "^0.0.8",
-        "tweetnacl": "^1.0.1",
-        "ws": "^7.2.1"
+        "tweetnacl": "^1.0.3",
+        "ws": "^8.2.3"
       }
     },
     "error-ex": {
@@ -7398,9 +7398,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "requires": {}
     },
     "xml2js": {
@@ -7429,9 +7429,9 @@
       "dev": true
     },
     "yuuko": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yuuko/-/yuuko-2.2.1.tgz",
-      "integrity": "sha512-iPfv7Ftkg6U2uh3HsUoBhznTxVbb/PiXGxxQp6GIuVxtUfC/oy1FiGhCZFJshnK7SgRGnER3SSxuvgsJR//k0A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yuuko/-/yuuko-2.3.2.tgz",
+      "integrity": "sha512-+EoC/tU70FafRhTTxxhPPJoU5odkV7n6EEd/yOvBH1BCignno9REneCGdlA1DMbS5lxoh3vEy1mO5rnRqQWNIA==",
       "requires": {}
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "another-logger": "^2.0.1",
     "connect-mongo": "^3.2.0",
     "convert-units": "^2.3.4",
-    "eris": "^0.15.0",
+    "eris": "^0.17.0",
     "express-session": "^1.17.0",
     "mongodb": "^3.5.5",
     "node-fetch": "^2.6.7",
     "polka": "^1.0.0-next.11",
     "rss-parser": "^3.12.0",
-    "yuuko": "^2.2.1"
+    "yuuko": "^2.3.2"
   },
   "devDependencies": {
     "@types/express-session": "^1.17.4",

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -20,6 +20,7 @@ export default (mongoClient, db) => {
 		// see https://github.com/discord/discord-api-docs/issues/2111 for alternatives
 		// #76
 		getAllUsers: true,
+		intents: ['all'],
 		// TODO: Remove when Eris is updated and this becomes default behavior
 		rest: {
 			decodeReasons: false,


### PR DESCRIPTION
Fixes #207. Fixes #192. Fixes #171.

Note: installing `yuuko@next` rather than `yuuko@latest` doesn't mean anything right now since there is no active prerelease of yuuko, but going forward if I do make prereleases in that library I will probably pull them in here early and use in-development features more actively here (since this codebase is basically the only real bot that uses yuuko and motivates my development of that library at this point).