### PR TITLE
Twitter feed support via Nitter

### DIFF
--- a/src/bot/events/rssFeeds.js
+++ b/src/bot/events/rssFeeds.js
@@ -40,9 +40,13 @@ function buildRssMessageContent (post, feedURL) {
 		// TODO: fetch author's avatar and display it in author.icon_url
 	}
 
-	if (feedURL.match()) {
-		return contentObject;
+	if (feedURL.match(/^https?:\/\/nitter/)) {
+		log.debug('it worked');
+		delete contentObject.embed;
+		contentObject.content = post.link.replace(/nitter.*?\//, 'twitter.com/').replace(/[?#].*$/, '');
 	}
+
+	return contentObject;
 }
 
 export default new EventListener('ready', ({client, db}) => {

--- a/src/bot/events/rssFeeds.js
+++ b/src/bot/events/rssFeeds.js
@@ -41,7 +41,6 @@ function buildRssMessageContent (post, feedURL) {
 	}
 
 	if (feedURL.match(/^https?:\/\/nitter/)) {
-		log.debug('it worked');
 		delete contentObject.embed;
 		contentObject.content = post.link.replace(/nitter.*?\//, 'twitter.com/').replace(/[?#].*$/, '');
 	}

--- a/src/bot/events/rssFeeds.js
+++ b/src/bot/events/rssFeeds.js
@@ -5,12 +5,12 @@ import Parser from 'rss-parser';
 const rssParser = new Parser();
 
 /**
- * Builds an embed object to use when posting a feed.
+ * Builds a message content object to use when posting a feed item.
  * @param {object} post The parsed feed entry to generate an embed for.
- * @param {string} url The URL of the source of the content.
+ * @param {string} feedURL The URL of the source of the content.
  * @returns {object}
  */
-function buildRssEmbed (post, url) {
+function buildRssMessageContent (post, feedURL) {
 	let tempTitle = post.title;
 	// titles in embeds have a 256 char limit
 	if (post.title.length > 253) {
@@ -18,26 +18,31 @@ function buildRssEmbed (post, url) {
 	}
 
 	// build embed
-	const embed = {
-		author: {
-			name: post.author,
-		},
-		title: tempTitle,
-		url: post.link,
-		timestamp: post.isoDate,
-		footer: {
-			text: url,
+	const contentObject = {
+		content: post.link,
+		embed: {
+			author: {
+				name: post.author,
+			},
+			title: tempTitle,
+			url: post.link,
+			timestamp: post.isoDate,
+			footer: {
+				text: feedURL,
+			},
 		},
 	};
 
 	// Unique processing for different services
-	if (url.match(/^https?:\/\/(\w+\.)?reddit\.com/)) {
-		embed.color = 0xFF4500;
-		embed.footer.icon_url = 'https://i.imgur.com/F66Nd8H.png';
+	if (feedURL.match(/^https?:\/\/(\w+\.)?reddit\.com/)) {
+		contentObject.embed.color = 0xFF4500;
+		contentObject.embed.footer.icon_url = 'https://i.imgur.com/F66Nd8H.png';
 		// TODO: fetch author's avatar and display it in author.icon_url
 	}
 
-	return embed;
+	if (feedURL.match()) {
+		return contentObject;
+	}
 }
 
 export default new EventListener('ready', ({client, db}) => {
@@ -61,9 +66,9 @@ export default new EventListener('ready', ({client, db}) => {
 				const itemDate = new Date(post.isoDate);
 				// If this item is from after the last check, process it
 				if (itemDate > storedFeed.lastCheck) {
-					const embed = buildRssEmbed(post, storedFeed.url);
+					const contentObject = buildRssMessageContent(post, storedFeed.url);
 					try {
-						const message = await client.createMessage(feedChannelID, {content: post.link, embed});
+						const message = await client.createMessage(feedChannelID, contentObject);
 						// If this is an announcement channel, publish the message
 						if (message.channel instanceof NewsChannel) {
 							await message.crosspost();


### PR DESCRIPTION
Fixes #217. Adds special handling for Nitter feeds in the RSS feed handler which posts them as Twitter links using normal Twitter embeds.

Nitter has multiple instances; the main one, https://nitter.net, seems to be somewhat slow, but they all work pretty much the same. To make a feed for the user, open up a nitter instance, find the user in the interface, then right-click the feed icon in the navbar and copy that link to use in the `createrssfeed` command.