### PR TITLE
Add unit aliases for temperature units

### DIFF
--- a/src/bot/commands/misc/convert.js
+++ b/src/bot/commands/misc/convert.js
@@ -106,6 +106,10 @@ const unitAliases = {
 	'feet': 'ft',
 	'inch': 'in',
 	'inches': 'in',
+	'f': 'F',
+	'c': 'C',
+	'k': 'K',
+	'r': 'R',
 };
 
 const command = new Command('convert', async (msg, args, context) => {


### PR DESCRIPTION
The command wasn't working when using lowercase temperature units before and this fixes that