### PR TITLE
Add guildId to rssFeeds collection schema

### DIFF
--- a/migrations/1650237364807-add-guildID-to-rssFeeds.js
+++ b/migrations/1650237364807-add-guildID-to-rssFeeds.js
@@ -1,0 +1,67 @@
+const {MongoClient} = require('mongodb');
+const config = require('../config');
+
+module.exports.up = async () => {
+	const mongoClient = new MongoClient(config.mongodb.url, {useUnifiedTopology: true});
+	await mongoClient.connect();
+	const db = mongoClient.db(config.mongodb.databaseName);
+
+	// Update validator to add guildID property
+	await db.command({
+		collMod: 'rssFeeds',
+		validator: {
+			$jsonSchema: {
+				bsonType: 'object',
+				required: ['name', 'url', 'guildID', 'channelId', 'lastCheck'],
+				properties: {
+					name: {
+						bsonType: 'string',
+					},
+					url: {
+						bsonType: 'string',
+					},
+					guildID: {
+						bsonType: 'string',
+					},
+					channelId: {
+						bsonType: 'string',
+					},
+					lastCheck: {
+						bsonType: 'date',
+					},
+				},
+			},
+		},
+	});
+};
+
+module.exports.down = async () => {
+	const mongoClient = new MongoClient(config.mongodb.url, {useUnifiedTopology: true});
+	await mongoClient.connect();
+	const db = mongoClient.db(config.mongodb.databaseName);
+
+	// Drop guildID from validator
+	await db.command({
+		collMod: 'rssFeeds',
+		validator: {
+			$jsonSchema: {
+				bsonType: 'object',
+				required: ['name', 'url', 'channelId', 'lastCheck'],
+				properties: {
+					name: {
+						bsonType: 'string',
+					},
+					url: {
+						bsonType: 'string',
+					},
+					channelId: {
+						bsonType: 'string',
+					},
+					lastCheck: {
+						bsonType: 'date',
+					},
+				},
+			},
+		},
+	});
+};

--- a/src/bot/commands/rss_feeds/createrssfeed.js
+++ b/src/bot/commands/rss_feeds/createrssfeed.js
@@ -14,8 +14,9 @@ const command = new Command('createrssfeed', async (message, args, context) => {
 
 	// try to get the channel
 	// NOTE: Although it reminds the user to make sure the channel is visible, it would still be able to find a channel regardless of its visiblity (but not read its contents)
+	let channel;
 	try {
-		context.client.getChannel(channelId) || await context.client.getRESTChannel(channelId);
+		channel = context.client.getChannel(channelId) || await context.client.getRESTChannel(channelId);
 	} catch (error) {
 		message.channel.createMessage('Couldn\'t find the channel with the specified ID. Please make sure it is visible to me and the ID is correct.').catch(() => {});
 		log.error(`Failed to locate channel ${escape(channelId)}:`, error);
@@ -35,6 +36,7 @@ const command = new Command('createrssfeed', async (message, args, context) => {
 		name: rssFeedName,
 		url: rssFeedUrl,
 		channelId,
+		guildId: channel.guild.id || null,
 		lastCheck: new Date(),
 	};
 

--- a/src/bot/commands/rss_feeds/deleterssfeed.js
+++ b/src/bot/commands/rss_feeds/deleterssfeed.js
@@ -11,7 +11,12 @@ const command = new Command('deleterssfeed', async (message, args, context) => {
 	const {db} = context;
 	const collection = db.collection('rssFeeds');
 	const rssFeedName = args[0];
-	await collection.deleteOne({name: rssFeedName})
+	await collection.deleteOne({
+		guildId: message.guildID,
+		// in DMs, filtering by guild isn't enough; filter to the specific DM
+		channelId: message.guildID ? undefined : message.channel.id,
+		name: rssFeedName,
+	})
 		.then(result => {
 			if (result.deletedCount === 0) {
 				message.channel.createMessage('Could not find anything to delete. Did you spell the name of the feed correctly?').catch(() => {});

--- a/src/bot/commands/rss_feeds/rssfeeds.js
+++ b/src/bot/commands/rss_feeds/rssfeeds.js
@@ -3,12 +3,19 @@ import {escape} from '../../util/formatting';
 
 const command = new Command('rssfeeds', async (message, args, {client, db}) => {
 	const collection = db.collection('rssFeeds');
-	let str = '';
-	const feeds = await collection.find().toArray();
-	if (feeds.length === 0) {
+
+	const feeds = await collection.find({
+		guildId: message.guildID,
+		// in DMs, filtering by guild isn't enough; filter to the specific DM
+		channelId: message.guildId ? undefined : message.channel.id,
+	}).toArray();
+
+	if (!feeds.length) {
 		message.channel.createMessage('No feeds found.').catch(() => { });
 		return;
 	}
+
+	let str = '';
 	for (const feed of feeds) {
 		const channelName = client.getChannel(feed.channelId).name;
 		str += `Feed: **${escape(feed.name)}**\nChannel: **${escape(channelName)}**\nURL: <${feed.url}> \n \n`;


### PR DESCRIPTION
Stores the guild where RSS feeds were created and filters by that guild (or, in DMs, the ID of the channel) when listing and deleting feeds. This fixes a bug where feeds would be exposed across servers, which we never encountered because nobody else uses this bot.

This will require manual migration of existing feeds after merging - for each existing feed, fetch the feed's channel and put its guild ID back into the object.