### PR TITLE
Limit audit log reasons for kicks and bans to 512 characters

### DIFF
--- a/src/bot/commands/moderation/ban.js
+++ b/src/bot/commands/moderation/ban.js
@@ -1,7 +1,7 @@
 import createLogger from 'another-logger';
 const log = createLogger({label: 'command:ban'});
 import {Command} from 'yuuko';
-import {parseUser, parseTime, formatDateRelative, awaitReaction} from '../../util/discord';
+import {parseUser, parseTime, formatDateRelative, awaitReaction, truncate} from '../../util/discord';
 import {escape, blockquote} from '../../util/formatting';
 
 const confirmationEmoji = '🔨';
@@ -61,7 +61,7 @@ const command = new Command('ban', async (message, args, context) => {
 	try {
 		// TODO: check if member is already banned before banning again
 		// TODO: service to clear bans after they expire
-		await message.channel.guild.banMember(user.id, 0, reason);
+		await message.channel.guild.banMember(user.id, 0, truncate(512, reason));
 	} catch (error) {
 		log.error(`Error banning user ${user.id} from guild ${message.channel.guild.id}:`, error);
 

--- a/src/bot/commands/moderation/ban.js
+++ b/src/bot/commands/moderation/ban.js
@@ -61,7 +61,7 @@ const command = new Command('ban', async (message, args, context) => {
 	try {
 		// TODO: check if member is already banned before banning again
 		// TODO: service to clear bans after they expire
-		await message.channel.guild.banMember(user.id, 0, truncate(512, reason));
+		await message.channel.guild.banMember(user.id, 0, truncate(reason, 512));
 	} catch (error) {
 		log.error(`Error banning user ${user.id} from guild ${message.channel.guild.id}:`, error);
 

--- a/src/bot/commands/moderation/kick.js
+++ b/src/bot/commands/moderation/kick.js
@@ -1,7 +1,7 @@
 import createLogger from 'another-logger';
 const log = createLogger({label: 'command:kick'});
 import {Command} from 'yuuko';
-import {parseGuildMember, awaitReaction} from '../../util/discord';
+import {parseGuildMember, awaitReaction, truncate} from '../../util/discord';
 import {escape, blockquote} from '../../util/formatting';
 
 const confirmationEmoji = '👢';
@@ -52,7 +52,7 @@ const command = new Command('kick', async (message, args, context) => {
 
 	// Kick the member
 	try {
-		await member.kick(reason);
+		await member.kick(truncate(512, reason));
 	} catch (error) {
 		log.error(`Error kicking user ${member.id} from guild ${message.channel.guild.id}:`, error);
 

--- a/src/bot/commands/moderation/kick.js
+++ b/src/bot/commands/moderation/kick.js
@@ -52,7 +52,7 @@ const command = new Command('kick', async (message, args, context) => {
 
 	// Kick the member
 	try {
-		await member.kick(truncate(512, reason));
+		await member.kick(truncate(reason, 512));
 	} catch (error) {
 		log.error(`Error kicking user ${member.id} from guild ${message.channel.guild.id}:`, error);
 

--- a/src/bot/commands/whois.js
+++ b/src/bot/commands/whois.js
@@ -1,7 +1,7 @@
 import createLogger from 'another-logger';
 const log = createLogger({label: 'cmd:whois'});
 import {Command} from 'yuuko';
-import {parseUser, formatDate} from '../util/discord';
+import {parseUser, formatDate, truncate} from '../util/discord';
 import {escape} from '../util/formatting';
 
 const {HOST} = process.env;
@@ -156,10 +156,7 @@ const command = new Command('whois', async (message, args, context) => {
 		notesLine(user.id, message.channel.guild.id, db),
 	])).join('\n\n');
 
-	if (content.length > 2000) {
-		const endIndicator = '\n\n\u2026'; // ellipsis as one character
-		content = content.slice(0, 2000 - endIndicator.length) + endIndicator;
-	}
+	content = truncate(content, 2000, '\n\n\u2026'); // U+2026 is an ellipsis
 
 	message.channel.createMessage({
 		content,

--- a/src/bot/events/rssFeeds.js
+++ b/src/bot/events/rssFeeds.js
@@ -2,6 +2,7 @@ import log from 'another-logger';
 import {EventListener} from 'yuuko';
 import {NewsChannel} from 'eris';
 import Parser from 'rss-parser';
+import {truncate} from '../util/discord';
 const rssParser = new Parser();
 
 /**
@@ -11,11 +12,8 @@ const rssParser = new Parser();
  * @returns {object}
  */
 function buildRssMessageContent (post, feedURL) {
-	let tempTitle = post.title;
 	// titles in embeds have a 256 char limit
-	if (post.title.length > 253) {
-		tempTitle = post.title.substring(0, 252).concat('...');
-	}
+	const tempTitle = truncate(post.title, 256);
 
 	// build embed
 	const contentObject = {

--- a/src/bot/util/discord.ts
+++ b/src/bot/util/discord.ts
@@ -220,3 +220,18 @@ export const formatDateRelative = (date: Date) => `<t:${Math.round(date.getTime(
 
 /** Size of avatars shown from the avatar and defaultavatar command */
 export const AVATAR_IMAGE_SIZE = 512;
+
+/**
+ * Truncates a string to the given number of characters, adding an ellipsis
+ * at the end if part of the string had to be cut off.
+ * @param n The maximum number of characters for the returned string
+ * @param str The string to be truncated
+ * @see https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object
+ */
+export function truncate (n: number, str: string) {
+	if (str.length <= n) {
+		return str;
+	}
+	// U+2026 is a single-character ellipsis
+	return `${str.slice(0, n - 1)}\u2026`;
+}

--- a/src/bot/util/discord.ts
+++ b/src/bot/util/discord.ts
@@ -228,7 +228,6 @@ export const AVATAR_IMAGE_SIZE = 512;
  * @param n The maximum number of characters for the returned string
  * @param cutoffIndicator A string added at the end of the result only if the
  * input string needed to be cut down. Defaults to a single-character ellipsis.
- * @see https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object
  */
 export function truncate (str: string, n: number, cutoffIndicator = '\u2026') {
 	if (str.length <= n) {

--- a/src/bot/util/discord.ts
+++ b/src/bot/util/discord.ts
@@ -222,16 +222,17 @@ export const formatDateRelative = (date: Date) => `<t:${Math.round(date.getTime(
 export const AVATAR_IMAGE_SIZE = 512;
 
 /**
- * Truncates a string to the given number of characters, adding an ellipsis
- * at the end if part of the string had to be cut off.
- * @param n The maximum number of characters for the returned string
+ * Truncates a string to the given number of characters, adding an ellipsis (or
+ * other indicator) at the end if part of the string had to be cut off.
  * @param str The string to be truncated
+ * @param n The maximum number of characters for the returned string
+ * @param cutoffIndicator A string added at the end of the result only if the
+ * input string needed to be cut down. Defaults to a single-character ellipsis.
  * @see https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object
  */
-export function truncate (n: number, str: string) {
+export function truncate (str: string, n: number, cutoffIndicator = '\u2026') {
 	if (str.length <= n) {
 		return str;
 	}
-	// U+2026 is a single-character ellipsis
-	return `${str.slice(0, n - 1)}\u2026`;
+	return `${str.slice(0, n - cutoffIndicator.length)}${cutoffIndicator}`;
 }


### PR DESCRIPTION
Fixes #252. Kick/ban messages longer than 512 characters will appear cut off with an ellipsis in the audit log.

Adds a helper for truncating strings and adding an ellipsis if necessary. Cleans up some other areas where we do similar things as well.